### PR TITLE
Use idiomatic environment var name OPENAI_API_KEY over OPENAI_KEY

### DIFF
--- a/agents/examples/chat.rs
+++ b/agents/examples/chat.rs
@@ -16,7 +16,7 @@ impl Person {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let model = GPT4::new(dotenv::var("OPENAI_KEY").unwrap());
+    let model = GPT4::new(dotenv::var("OPENAI_API_KEY").unwrap());
 
     let mut joseph = Person::new(&model, "Joseph");
     let mut maria = Person::new(&model, "Maria");


### PR DESCRIPTION
As far as I can find, OPENAI_KEY is not a typical environment variable compared to using OPENAI_API_KEY.